### PR TITLE
Update "time" dependency bounds

### DIFF
--- a/linux-evdev.cabal
+++ b/linux-evdev.cabal
@@ -17,7 +17,7 @@ Library
                      System.Linux.Input.Device
   Build-tools:       hsc2hs
   Build-depends:     base           >= 4.0         && < 5.0,
-                     time           >= 1.4         && < 1.9,
+                     time           >= 1.4         && < 1.10,
                      bytestring     >= 0.9         && < 0.11,
                      unix           >= 2.6         && < 2.8
  


### PR DESCRIPTION
In order to comply [fresh stack snapshot](https://www.stackage.org/nightly-2019-10-10) (and also latest version of `time` package in general).

I've personally tested that it successfully builds with [time-1.9.3](https://www.stackage.org/nightly-2019-10-10/package/time-1.9.3).