### PR TITLE
Fix building with GHC 9.2.3

### DIFF
--- a/linux-evdev.cabal
+++ b/linux-evdev.cabal
@@ -9,7 +9,7 @@ Author:              Ben Gamari
 Maintainer:          bgamari.foss@gmail.com
 Category:            System
 Build-type:          Simple
-Cabal-version:       >=1.6
+Cabal-version:       >=1.8
 Homepage:            http://github.com/bgamari/linux-evdev
 
 Library
@@ -18,9 +18,9 @@ Library
                      System.Linux.Input.Device
   Build-tools:       hsc2hs
   Build-depends:     base           >= 4.0         && < 5.0,
-                     time           >= 1.4         && < 1.10,
-                     bytestring     >= 0.9         && < 0.11,
-                     unix           >= 2.6         && < 2.8
+                     time           >= 1.4         && < 2,
+                     bytestring     >= 0.9         && < 0.12,
+                     unix           >= 2.6         && < 3
  
 source-repository head
   type:              git


### PR DESCRIPTION
Update minimal Cabal version requirement from `1.6` to `1.8`.
Update version bounds.

Only Cabal file is affected.
New need for new release. A revision should do.